### PR TITLE
Fix replyToPost missing export and pass cid to reply call.

### DIFF
--- a/bluesky/atproto.js
+++ b/bluesky/atproto.js
@@ -90,4 +90,17 @@ async function postThread(agent, messages) {
   return rootPost;
 }
 
-module.exports = { setupAgent, buildHashtagFacets, buildLinkFacet, post, postThread };
+async function replyToPost(agent, { uri, cid, text }) {
+  const facets = buildHashtagFacets(text);
+  return await agent.post({
+    text,
+    createdAt: new Date().toISOString(),
+    facets,
+    reply: {
+      root: { uri, cid },
+      parent: { uri, cid },
+    },
+  });
+}
+
+module.exports = { setupAgent, buildHashtagFacets, buildLinkFacet, post, postThread, replyToPost };

--- a/bluesky/mentions.js
+++ b/bluesky/mentions.js
@@ -87,7 +87,7 @@ async function processMentions({ limit = 50 } = {}) {
         replyText = await generateReply({ risingSign, moonContext, house, userText });
       }
 
-      await replyToPost(agent, { uri: n.uri, text: replyText });
+      await replyToPost(agent, { uri: n.uri, cid: n.cid, text: replyText });
 
       processed.add(key);
       replied++;


### PR DESCRIPTION
The goal of this pull request (PR) is to address two specific issues in the code related to replying to posts:

- Export the replyToPost function: The PR ensures that the replyToPost function is properly exported, likely to make it accessible in other parts of the codebase or for external use.

- Pass cid to the reply call: The PR modifies the reply call so that it correctly passes the cid (Content Identifier), which is probably necessary for accurately threading or referencing replies to posts.

In summary:
This PR fixes a missing export for the replyToPost function and updates the reply logic to include the cid identifier when sending a reply, improving proper post referencing and integration in the codebase.